### PR TITLE
Chat does not open on Safari

### DIFF
--- a/chat/fe/src/services/NotificationService.ts
+++ b/chat/fe/src/services/NotificationService.ts
@@ -1,13 +1,29 @@
 let notificationsEnabled = false;
 
-export function initializeNotificationService() {
-  notificationsEnabled = localStorage.getItem("notifications") === "true";
+function checkNotificationPromise() {
+  try {
+    Notification.requestPermission().then();
+  } catch (err) {
+    console.error(err);
+    return false;
+  }
 
-  return Notification.requestPermission()
-    .then()
-    .catch((err) => {
-      console.error(err);
-    });
+  return true;
+}
+
+export function initializeNotificationService() {
+  notificationsEnabled = localStorage.getItem('notifications') === 'true';
+
+  if (!('Notification' in window)) {
+    return;
+  }
+
+  const isNotificationsPromiseSupported = checkNotificationPromise();
+
+  if (!isNotificationsPromiseSupported) {
+    /* Safari does not support the promise-based version */
+    Notification.requestPermission();
+  }
 }
 
 export function areNotificationsEnabled() {
@@ -18,8 +34,8 @@ export function toggleNotificationsEnabled() {
   notificationsEnabled = !notificationsEnabled;
 
   localStorage.setItem(
-    "notifications",
-    notificationsEnabled ? "true" : "false"
+    'notifications',
+    notificationsEnabled ? 'true' : 'false'
   );
 }
 


### PR DESCRIPTION
The requestPermission() method of Notifications uses a promise syntax, however Safari still uses the old callback syntax which does isn't allowing the chat app to open on Safari browsers. 

Solution:
- Added a check to use the callback if the promise syntax fails. 
- Additionally, added a check to return early if the web notification API isn't available (for example Safari IOS)