### PR TITLE
Open rooms on Safari IOS

### DIFF
--- a/chat/fe/src/utils/HistoryUtils.ts
+++ b/chat/fe/src/utils/HistoryUtils.ts
@@ -1,6 +1,6 @@
-const baseURL = "http://localhost:1337"
+const baseURL = 'http://localhost:1337';
 
 export function setURL(url: string) {
-  history.pushState({}, "", new URL(`${baseURL}${url}`));
+  history.pushState({}, '', url);
   window.dispatchEvent(new Event('popstate'));
 }


### PR DESCRIPTION
Clicking/tapping on a room would not open it on iPhone. Changing the third parameter to only the extension of the url without the base url seems to work and open the rooms on desktop and mobile.