### PR TITLE
Fix #174 horizontal scroll on long links

### DIFF
--- a/chat/fe/src/views/RoomView.ts
+++ b/chat/fe/src/views/RoomView.ts
@@ -82,6 +82,7 @@ export function RoomView(props: RoomViewProps) {
     setStyle(el, {
       display: 'flex',
       margin: '4px 0px',
+      overflowWrap: 'Anywhere',
     });
 
     onMouseOver(el, (e) => {
@@ -234,6 +235,7 @@ export function RoomView(props: RoomViewProps) {
         setStyle(option, {
           margin: '0',
           padding: '8px 12px',
+          overflowWrap: 'Normal',
         });
         option.innerHTML = 'Delete';
 


### PR DESCRIPTION
### **Before**
Inserting a long link puts it on a single line, allowing whole chat window to horizontally scroll.
![before_desktop](https://user-images.githubusercontent.com/77360100/167457086-ca7fefd2-3ec9-40cc-b5e3-03e646f80594.png)
![before_mobile](https://user-images.githubusercontent.com/77360100/167457120-7ba2aa0e-165c-48da-8ecd-10b71d99c72d.png)

### **After**
Inserting long links will properly wrap removing chat window horizontal scroll.
![after_mobile](https://user-images.githubusercontent.com/77360100/167457420-24075a41-3080-4f8f-a185-4a07c9e3d56b.png)
![after_desktop](https://user-images.githubusercontent.com/77360100/167457474-c55c9d31-983d-4198-90b2-74d4bab5f017.png)

