### PR TITLE
Add silenced notifications while in same page as sent message

### DIFF
--- a/chat/fe/src/services/NotificationService.ts
+++ b/chat/fe/src/services/NotificationService.ts
@@ -47,11 +47,14 @@ type SendNotificationParams = {
   roomId: string;
 };
 
+export function inSameRoom(roomID: string) {
+  return (document.URL.includes(roomID) && document.hasFocus()) ? true : false;
+}
+
 export function sendNotification(params: SendNotificationParams) {
-  if (!areNotificationsEnabled()) {
+  if (!areNotificationsEnabled() || inSameRoom(params.roomId)) {
     return;
   }
-
   const notification = new Notification(params.title, { body: params.body });
   notification.onclick = () => {
     window.focus()


### PR DESCRIPTION
If user clicked into the same room as message sent, no notification should pop up. Needs to be tested after deploy