### PR TITLE
Dmsayo/196/push notifications in active room

### DIFF
--- a/chat/fe/public/service-worker.js
+++ b/chat/fe/public/service-worker.js
@@ -1,14 +1,35 @@
 self.addEventListener('push', (e) => {
     const message = e.data.json();
+    const roomUrl = ('/rooms/' + message.room.id);
     e.waitUntil(
-        self.registration.showNotification(message.title, {
-            body: message.body,
-            data: {
-                roomId: message.room,
-            }
+        clients.matchAll({
+            type: 'window'
         })
+            .then(clientList => {
+                for (let i = 0; i < clientList.length; i++) {
+                    let client = clientList[i];
+                    if (!(client.focused) || !(client.url.includes(roomUrl))) {
+                        self.registration.showNotification(message.title, {
+                            body: message.body,
+                            data: {
+                                roomId: message.room,
+                            }
+
+                        })
+                        break;
+                    }
+                }
+            })
+
     );
 })
+
+        // self.registration.showNotification(message.title, {
+        //     body: message.body,
+        //     data: {
+        //         roomId: message.room,
+        //     }
+        // })
 
 self.addEventListener('notificationclick', (e) => {
     const roomUrl = ('/rooms/' + e.notification.data.roomId.id);
@@ -29,7 +50,7 @@ self.addEventListener('notificationclick', (e) => {
                         break;
                     }
                 }
-                
+
                 if (!windowMatchFound) {
                     return clients.openWindow(roomUrl);
 


### PR DESCRIPTION
Prevents push notification being sent while user is actively tabbed into the same room as the message being sent. 

Notes: I wasn't able to fully get this to work on Firefox since the window client url didn't change until the window was hard refreshed. I am unsure whether this is an environment issue with my Firefox or a localhost issue, we can keep a lookout if it causes issues. I can confirm this change works on Chrome, Opera, and Edge.